### PR TITLE
VATRP-2450: Remove AppCompat activity. Crashes newer Android devices on clean install.…

### DIFF
--- a/Android/app/src/main/java/joanbempong/android/HomeActivity.java
+++ b/Android/app/src/main/java/joanbempong/android/HomeActivity.java
@@ -1,17 +1,18 @@
 package joanbempong.android;
 
-import org.linphone.R;
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import org.linphone.R;
+
 import java.util.ArrayList;
 
-public class HomeActivity extends AppCompatActivity {
+public class HomeActivity extends Activity {
 
     SetupController setupController;
     ListView listContacts;


### PR DESCRIPTION
… Activity will be just fine.
